### PR TITLE
feat: add support for brew install path

### DIFF
--- a/rbuild.py
+++ b/rbuild.py
@@ -19,6 +19,15 @@ if os.name == "posix":
     if 'darwin' in sys.platform:
         print("Operating System: macOS")
         PATH_TO_OPENSCAD = '/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
+
+        ALTERNATE_PATHS = [
+            '/Applications/OpenSCAD-2021.01.app/Contents/MacOS/OpenSCAD' # `brew install openscad`
+        ]
+        
+        for path in ALTERNATE_PATHS:
+            if binary_exists(path):
+                PATH_TO_OPENSCAD = path
+                break
     else:  # Assume Linux if not macOS
         print("Operating System: Linux")
         PATH_TO_OPENSCAD = '/usr/bin/openscad'


### PR DESCRIPTION
**Summary**

It would be ideal if `rbuild.py` would support fairly standard installation paths and auto-detect them.  When installing `openscad` from `brew` that path is `/Applications/OpenSCAD-2021.01.app`.  

- Closes #49 

**Changes**

Default on macOS to the existing `/Applications/OpenSCAD.app` path, unless the Brew path is present.

**Brew Install**

```
% brew reinstall openscad
==> Fetching downloads for: openscad
✔︎ Cask openscad (2021.01)                                           [Verified     28.8MB/ 28.8MB]
==> Caveats
openscad is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.

==> Uninstalling Cask openscad
==> Backing App 'OpenSCAD-2021.01.app' up to '/opt/homebrew/Caskroom/openscad/2021.01/OpenSCAD-20
==> Removing App '/Applications/OpenSCAD-2021.01.app'
==> Unlinking Binary '/opt/homebrew/bin/openscad'
==> Purging files for version 2021.01 of Cask openscad
==> Installing Cask openscad
==> Moving App 'OpenSCAD-2021.01.app' to '/Applications/OpenSCAD-2021.01.app'
==> Linking Binary 'OpenSCAD' to '/opt/homebrew/bin/openscad'
🍺  openscad was successfully installed!
```

**Running After Change**
```
% which openscad
/opt/homebrew/bin/openscad

% ls -lah /opt/homebrew/bin/openscad
lrwxr-xr-x  1 stan  admin    58B Dec 29 00:05 /opt/homebrew/bin/openscad -> /Applications/OpenSCAD-2021.01.app/Contents/MacOS/OpenSCAD

% ./rbuild.py
Operating System: macOS
Please either provide the build (-b) variable, or the build-gifs option (--build-gifs)
```

